### PR TITLE
Termin kopieren - "Kopie" anhängen und deaktivieren

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -75,6 +75,7 @@ rex_forcal_entries_toggle_status_error = Der Status des Termins konnte nicht ge�
 rex_forcal_entries_toggle_status_success = Der Status des Termins wurde geändert.
 rex_forcal_entries_deleted = Der Termin wurde gelöscht.
 rex_forcal_entries_cloned = Der Termin wurde dupliziert.
+rex_forcal_entries_copy = Kopie
 
 ### entry list
 forcal_entry_list_view = Termine

--- a/lib/forcal/Utils/forcalListHelper.php
+++ b/lib/forcal/Utils/forcalListHelper.php
@@ -110,6 +110,10 @@ class forCalListHelper
             }
         }
         $sql->setQuery('INSERT INTO ' . $table . ' (`' . implode('`, `', $queryFields) . '`) SELECT `' . implode('`, `', $queryFields) . '` FROM ' . $table . ' WHERE id =' . $id);
+        $lastId = $sql->getLastId();
+        $sql->setQuery('SELECT name_1 FROM ' . $table . ' WHERE id = '. $lastId);
+        $newName = $sql->getValue('name_1').' - '.rex_i18n::msg('rex_forcal_entries_copy');
+        $sql->setQuery('UPDATE ' . $table . ' SET name_1 = "'.$newName.'", status = 0 WHERE id = '.$lastId);
         return rex_view::info(rex_i18n::msg($table . '_cloned'));
     }
 


### PR DESCRIPTION
Beim Duplizieren wird nun hinten " - Kopie" angehängt und der Status auf 0 gesetzt.

Bezüglich https://github.com/FriendsOfREDAXO/forcal/issues/4