### PR TITLE
fix: update tab styles

### DIFF
--- a/assets/forcal.css
+++ b/assets/forcal.css
@@ -129,7 +129,7 @@ body.modal-open {
     border-bottom: 1px solid #bfe0d8;
 }
 
-.nav-tabs > li.active > a, .nav-tabs > li.active > a:hover, .nav-tabs > li.active > a:focus {
+.forcal_clangtabs .nav-tabs > li.active > a, .nav-tabs > li.active > a:hover, .nav-tabs > li.active > a:focus {
     background-color: #f1fcfa;
     border-color: #bfe0d8;
     border-top: 2px solid #3bb594;
@@ -137,14 +137,14 @@ body.modal-open {
     border-radius: 4px 4px 0 0;
 }
 
-.nav-tabs > li > a {
+.forcal_clangtabs .nav-tabs > li > a {
     color: #333;
     background-color: #e6eaf0;
     border-color: #f1f6fc;
     border-radius: 4px 4px 0 0;
 }
 
-.nav-tabs > li > a:hover {
+.forcal_clangtabs .nav-tabs > li > a:hover {
     color: #fff;
     background-color: #3bb594;
     border-color: #3bb594;


### PR DESCRIPTION
Mir ist aufgefallen das die Tab-Styles globale Styles überschreiben. 
Ich habe die Tabs nur für die Sprache finden können, sollte dies nicht der Fall sein muss ich den PR noch ein mal überarbeiten. 