### PR TITLE
defaultSort Parameter beim Erstellen des Listenobjekts ergänzt

### DIFF
--- a/pages/entries.php
+++ b/pages/entries.php
@@ -10,7 +10,6 @@ $itemDate = rex_request::request('itemdate', 'string', null);
 $id = rex_request::request('id', 'int');
 $start = rex_request::request('start', 'int', NULL);
 $categoryFilter = rex_request::request('category_filter', 'int', NULL);
-$sorttype = rex_request::request('sorttype', 'string', NULL);
 
 $tableEvent = rex::getTablePrefix() . "forcal_entries";
 $tableCategories = rex::getTablePrefix() . "forcal_categories";
@@ -63,18 +62,11 @@ if ($func == '' || $func == 'filter') {
         $where = '';
     }
 
-    $sort = "DESC";
-
-    if(strtoupper($sorttype)==="DESC"||strtoupper($sorttype)==="ASC"){
-        $sort = $sorttype;
-    }
-
     // init list
     $list = rex_list::factory('SELECT ' . implode(', ', $select) . '
             FROM ' . $tableEvent . ' AS en
             LEFT JOIN ' . $tableCategories . ' AS ca ON en.category = ca.id
-            ' . $where . '
-            ORDER BY en.start_date '. $sort .', en.start_time DESC', 30, null, false);
+            ' . $where , 30, null, false, 1, ['start_date'=>'desc','category'=>'desc']);
     $list->addTableAttribute('class', 'table-striped');
 
     // merge group with default


### PR DESCRIPTION
Scheinbar muss beim Erstellen eines Listenobjekts mit `rex_list::factory ` der Parameter _defaultSort_ angegeben werden, damit das Sortieren der Einträge vollständig funktioniert. Damit wird die vorherige Lösung, wobei der Parameter _sorttype_ aus der URL ausgelesen wurde, überflüssig.