### PR TITLE
Add check for empty fieldset and update attribute check

### DIFF
--- a/lib/forcal/Handler/forcalFormFieldsetHandler.php
+++ b/lib/forcal/Handler/forcalFormFieldsetHandler.php
@@ -40,6 +40,8 @@ class forCalFormFieldsetHandler
      */
     public static function handleFormFieldset(rex_form $form, $fieldset, rex_clang $clang, $langField = false)
     {
+        if (empty($fieldset)) return;
+
         foreach ($fieldset as $key => $field) {
 
             if (array_key_exists('panel', $field) && array_key_exists('fields', $field)) {
@@ -367,7 +369,7 @@ class forCalFormFieldsetHandler
             if (is_object($formField)) {
                 $formField->setNotice(self::getNotice($field));
 
-                if (array_key_exists('attribute', $field)) {
+                if (!empty($field['attribute'])) {
                     foreach ($field['attribute'] as $at_key => $at_value) {
                         $formField->setAttribute($at_key, $at_value);
                     }


### PR DESCRIPTION
 Fixes two PHP warnings 
                                                                                                                                                                                                                                                                                                                   
$fieldset can be null (line 43):

_if (empty($fieldset)) return;_
_foreach ($fieldset as $key => $field) {_

                                                                                                                                                                                                                                                                                                                   

$field['attribute'] can be null (line 370): array_key_exists() returns true even if the value is null :
                                                                                                                                                                                                                          // before
_if (array_key_exists('attribute', $field)) {_
                                                                                                                                                                                                                         // after
_if (!empty($field['attribute'])) {_